### PR TITLE
Set EVP_CIPHER_CTX_FLAG_WRAP_ALLOW for OpenSSL 1.1

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AesImplementation.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AesImplementation.OpenSsl.cs
@@ -71,6 +71,7 @@ namespace System.Security.Cryptography
 
                     if (ctx.IsInvalid)
                     {
+                        ctx.Dispose();
                         throw Interop.Crypto.CreateOpenSslCryptographicException();
                     }
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AesImplementation.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AesImplementation.OpenSsl.cs
@@ -62,12 +62,19 @@ namespace System.Security.Cryptography
 
                     IntPtr algorithm = GetKeyWrapAlgorithm(keySizeInBits);
 
-                    return Interop.Crypto.EvpCipherCreate(
+                    SafeEvpCipherCtxHandle ctx = Interop.Crypto.EvpCipherCreate(
                         algorithm,
                         ref MemoryMarshal.GetReference(key),
                         key.Length * 8,
                         ref MemoryMarshal.GetReference(ReadOnlySpan<byte>.Empty),
                         enc);
+
+                    if (ctx.IsInvalid)
+                    {
+                        throw Interop.Crypto.CreateOpenSslCryptographicException();
+                    }
+
+                    return ctx;
                 });
 
             int written;

--- a/src/native/libs/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/native/libs/System.Security.Cryptography.Native/opensslshim.h
@@ -475,6 +475,7 @@ extern bool g_libSslUses32BitTime;
     LEGACY_FUNCTION(EVP_CIPHER_CTX_init) \
     FALLBACK_FUNCTION(EVP_CIPHER_CTX_new) \
     FALLBACK_FUNCTION(EVP_CIPHER_CTX_reset) \
+    REQUIRED_FUNCTION(EVP_CIPHER_CTX_set_flags) \
     REQUIRED_FUNCTION(EVP_CIPHER_CTX_set_key_length) \
     REQUIRED_FUNCTION(EVP_CIPHER_CTX_set_padding) \
     RENAMED_FUNCTION(EVP_CIPHER_get_nid, EVP_CIPHER_nid) \
@@ -1050,6 +1051,7 @@ extern TYPEOF(OPENSSL_gmtime)* OPENSSL_gmtime_ptr;
 #define EVP_CIPHER_CTX_init EVP_CIPHER_CTX_init_ptr
 #define EVP_CIPHER_CTX_new EVP_CIPHER_CTX_new_ptr
 #define EVP_CIPHER_CTX_reset EVP_CIPHER_CTX_reset_ptr
+#define EVP_CIPHER_CTX_set_flags EVP_CIPHER_CTX_set_flags_ptr
 #define EVP_CIPHER_CTX_set_key_length EVP_CIPHER_CTX_set_key_length_ptr
 #define EVP_CIPHER_CTX_set_padding EVP_CIPHER_CTX_set_padding_ptr
 #define EVP_CIPHER_get_nid EVP_CIPHER_get_nid_ptr

--- a/src/native/libs/System.Security.Cryptography.Native/pal_evp_cipher.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_evp_cipher.c
@@ -30,6 +30,9 @@ CryptoNative_EvpCipherCreate2(const EVP_CIPHER* type, uint8_t* key, int32_t keyL
         return NULL;
     }
 
+    // Required for OpenSSL 1.1 AES-KWP, no-op in OpenSSL 3.
+    EVP_CIPHER_CTX_set_flags(ctx, EVP_CIPHER_CTX_FLAG_WRAP_ALLOW);
+
     // Perform partial initialization so we can set the key lengths
     int ret = EVP_CipherInit_ex(ctx, type, NULL, NULL, NULL, 0);
     if (!ret)

--- a/src/native/libs/System.Security.Cryptography.Native/pal_evp_cipher.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_evp_cipher.c
@@ -8,6 +8,8 @@
 #define SUCCESS 1
 #define KEEP_CURRENT_DIRECTION -1
 
+c_static_assert(EVP_CIPHER_CTX_FLAG_WRAP_ALLOW == 1);
+
 EVP_CIPHER_CTX*
 CryptoNative_EvpCipherCreate2(const EVP_CIPHER* type, uint8_t* key, int32_t keyLength, unsigned char* iv, int32_t enc)
 {


### PR DESCRIPTION
This also adds error checking when creating the context.